### PR TITLE
Normalize exception usage

### DIFF
--- a/nintendeals/api/prices.py
+++ b/nintendeals/api/prices.py
@@ -52,7 +52,6 @@ def _fetch_prices(country: str, nsuids: List[str]) -> Dict[str, Price]:
 
         prices[price.nsuid] = price
 
-    print(f" * Found {found} prices and {sales} sales")
     return prices
 
 

--- a/nintendeals/classes/games.py
+++ b/nintendeals/classes/games.py
@@ -4,6 +4,7 @@ from typing import List
 from nintendeals.api.prices import get_price
 from nintendeals.classes.prices import Price
 from nintendeals.constants import PLATFORMS, REGIONS
+from nintendeals.exceptions import InvalidTitle, InvalidRegion, UnsupportedPlatform
 from nintendeals import validate
 
 ESHOP_URL = 'https://ec.nintendo.com/{country}/{lang}/titles/{nsuid}'
@@ -19,9 +20,9 @@ class Game:
         nsuid: str = None,
         product_code: str = None,
     ):
-        assert title
-        assert region in REGIONS
-        assert platform in PLATFORMS
+        if not title: raise InvalidTitle(title)
+        if not region in REGIONS: raise InvalidRegion(region)
+        if not platform in PLATFORMS: raise UnsupportedPlatform(platform)
 
         self.title: str = title
         self.region: str = region

--- a/nintendeals/exceptions.py
+++ b/nintendeals/exceptions.py
@@ -26,6 +26,6 @@ class InvalidRegion(ValueError):
         )
 
 
-class UnsupportedPlaform(ValueError):
+class UnsupportedPlatform(ValueError):
     def __init__(self, platform: str):
         super().__init__(f"The platform {platform} is not supported.")

--- a/nintendeals/exceptions.py
+++ b/nintendeals/exceptions.py
@@ -29,3 +29,16 @@ class InvalidRegion(ValueError):
 class UnsupportedPlatform(ValueError):
     def __init__(self, platform: str):
         super().__init__(f"The platform {platform} is not supported.")
+
+
+class NsuidMismatch(ValueError):
+    def __init__(self, nsuids: tuple):
+        super().__init__(f"Two or more nsuids mismatched unexpectedly: {nsuids}")
+
+
+class InvalidTitle(TypeError):
+    def __init__(self, title: str):
+        super().__init__(
+            f"The title '{title}' cannot be"
+            f" an empty string or None"
+        )

--- a/nintendeals/noa/external/algolia.py
+++ b/nintendeals/noa/external/algolia.py
@@ -3,6 +3,7 @@ import json
 from algoliasearch.search_client import SearchClient
 
 from nintendeals.constants import SWITCH
+from nintendeals.exceptions import UnsupportedPlatform
 
 APP_ID = "U3B6GR4UA3"
 API_KEY = "9a20c93440cf63cf1a7008d75f7438bf"
@@ -38,8 +39,11 @@ def find_by_nsuid(nsuid: str) -> str:
 
 
 def search_games(platform: str) -> json:
-    assert platform in PLATFORM_CODES
-    platform_code = PLATFORM_CODES[platform]
+    try:
+        platform_code = PLATFORM_CODES[platform]
+
+    except KeyError:
+        raise UnsupportedPlatform(platform)
 
     options = {
         "allowTyposOnNumericTokens": False,

--- a/nintendeals/noe/listing.py
+++ b/nintendeals/noe/listing.py
@@ -4,6 +4,7 @@ from typing import Iterator
 import requests
 
 from nintendeals.classes.games import Game
+from nintendeals.exceptions import UnsupportedPlatform
 from nintendeals.constants import EU, SWITCH
 
 LISTING_URL = 'https://search.nintendo-europe.com/en/select'
@@ -53,7 +54,7 @@ def list_games(platform: str) -> Iterator[Game]:
     Iterator[classes.nintendeals.games.Game]:
         Partial information of a game provided by NoE.
     """
-    assert platform in SYSTEM_NAMES
+    if not platform in SYSTEM_NAMES: raise UnsupportedPlatform(platform)
     system_name = SYSTEM_NAMES[platform]
 
     rows = 200

--- a/nintendeals/noj/info.py
+++ b/nintendeals/noj/info.py
@@ -5,6 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from nintendeals.classes.games import Game
+from nintendeals.exceptions import NsuidMismatch
 from nintendeals.constants import JP, PLATFORMS
 
 DETAIL_URL = "https://ec.nintendo.com/JP/jp/titles/{nsuid}"
@@ -29,7 +30,7 @@ def _scrap(url: str) -> Game:
     nsuid = str(data["id"])
     extra_info = _get_extra_info(nsuid)
 
-    assert extra_info["nsuid"] == nsuid
+    if extra_info["nsuid"] != nsuid: raise NsuidMismatch((nsuid, extra_info["nsuid"]))
 
     platform = data["platform"]["name"]
     product_code = f"{extra_info['hard'].replace('1_', '')}{extra_info['icode']}"

--- a/nintendeals/noj/listing.py
+++ b/nintendeals/noj/listing.py
@@ -5,6 +5,7 @@ import requests
 import xmltodict
 
 from nintendeals.classes.games import Game
+from nintendeals.exceptions import UnsupportedPlatform
 from nintendeals.constants import JP, SWITCH
 
 LISTING_URL = 'https://www.nintendo.co.jp/data/software/xml/{platform}.xml'
@@ -42,7 +43,7 @@ def list_games(platform: str) -> Iterator[Game]:
     Iterator[classes.nintendeals.games.Game]:
         Partial information of a game provided by NoJ.
     """
-    assert platform in FILENAMES
+    if not platform in FILENAMES: raise UnsupportedPlatform(platform)
 
     url = LISTING_URL.format(platform=FILENAMES.get(platform))
     response = requests.get(url)

--- a/nintendeals/validate.py
+++ b/nintendeals/validate.py
@@ -7,7 +7,7 @@ from nintendeals.exceptions import (
     InvalidAlpha2Code,
     InvalidNsuidFormat,
     InvalidRegion,
-    UnsupportedPlaform,
+    UnsupportedPlatform,
 )
 
 NSUID_REGEX = re.compile(r"\d001\d{10}")
@@ -92,7 +92,7 @@ def supported_platform(platform: str):
         The `platform` wasn't supported.
     """
     if platform not in PLATFORMS:
-        raise UnsupportedPlaform(platform)
+        raise UnsupportedPlatform(platform)
 
 
 def nintendo_region(region: str):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -69,5 +69,5 @@ class TestValidate(TestCase):
             validate.supported_platform(string)
             return
 
-        with self.assertRaises(exceptions.UnsupportedPlaform):
+        with self.assertRaises(exceptions.UnsupportedPlatform):
             validate.supported_platform(string)


### PR DESCRIPTION
This PR removes all references to `assert` in lieu of proper and descriptive exception classes. Because this changes the exceptions raised by certain functions this is a breaking change. Additionally, both a misspelled exception class has been fixed, and a debug print removed.

Files impacted by breaking change:
* `classes.games`
* `exceptions`
* `noa.external.algolia`
* `noe.listing`
* `noj.info`
* `noj.listing`